### PR TITLE
[finishes #171398241] Correct hub label id

### DIFF
--- a/lib/pivotal_card_checker.rb
+++ b/lib/pivotal_card_checker.rb
@@ -39,7 +39,7 @@ module PivotalCardChecker
   # Used by DeployCardCreator, to get the cards labels.
   ALL_SYS_LABEL_IDS = [2_162_869, 3_091_513, 11_686_698, 2_359_297, 2_090_081,
                        18_741_299, 2_713_317, 7_254_766, 13_055_644, 12_244_398, 
-                       21_569_494, 21_610_625, 21_569_494].freeze
+                       21_569_494, 21_610_625, 21_990_472].freeze
 
   # Used in DeployCardCreator and StoryCard.
   ALL_SYSTEM_LABELS = ['cms', 'billing engine', 'dct', 'reader', 'marketing',


### PR DESCRIPTION
When we have commits to both hub and admin, it would try to create a new card with the same "hedgeye-admin" label twice; and the system would reject it? Also none of the deploy cards have the hub label