### PR TITLE
[finishes #175810356] Fix configuration label

### DIFF
--- a/lib/pivotal_card_checker/checkers/sys_label_checker.rb
+++ b/lib/pivotal_card_checker/checkers/sys_label_checker.rb
@@ -19,8 +19,8 @@ module PivotalCardChecker
       # @results Hash.
       def sys_label_violation_check(story_card, sys_labels_on_story)
         sys_labels_from_comments = story_card.get_system_label_from_commit
-        if sys_labels_on_story.empty?
-          if sys_labels_from_comments.empty? && !story_card.configuration_label?
+        if sys_labels_on_story.empty? && !story_card.configuration_label?
+          if sys_labels_from_comments.empty?
             @results[story_card] = 'No system labels detected (reader, cms, dct, etc...)'
           else
             @results[story_card] = "Did not find expected label(s): '#{sys_labels_from_comments.join('\', \'')}'"


### PR DESCRIPTION
Don't complain about system label commits if using `configuration` label